### PR TITLE
fix: don't bump Python and Node versions in Dockerfile

### DIFF
--- a/default.json
+++ b/default.json
@@ -33,6 +33,11 @@
     {
       "sourceUrlPrefixes": ["https://github.com/facebook/relay"],
       "groupName": "Relay monorepo"
+    },
+    {
+      "matchPackageNames": ["python", "node"],
+      "matchManagers": ["dockerfile"],
+      "enabled": false
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
## what

- attempt to disable Python and Node updates in Dockerfile

taken from https://docs.renovatebot.com/configuration-options/#matchmanagers

## why

- currently renovate will include Python upgrades as a "non-major dependency update", e.g. https://github.com/ButterflyNetwork/olympus-storage/pull/1864/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1 , which isn't what we want