### PR TITLE
feat: add pip-compile support

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,6 +11,9 @@
   "pip_requirements": {
     "fileMatch": ["(^|/)requirements(-dev)?\\.txt"]
   },
+  "pip-compile": {
+    "fileMatch": ["(^|/)requirements(-dev)?\\.in"]
+  },
   "pip_setup": {
     "enabled": false
   },


### PR DESCRIPTION
https://docs.renovatebot.com/modules/manager/pip-compile/

current, merging renovate PRs on python services requires manually running pip-compile. hopefully this obviates that.