### PR TITLE
chore: treat fourmat minor updates as major

### DIFF
--- a/default.json
+++ b/default.json
@@ -41,6 +41,11 @@
       "matchPackageNames": ["python", "node"],
       "matchManagers": ["dockerfile"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["fourmat"],
+      "updateTypes": ["minor"],
+      "versioning": "lockfile-major"
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
This should make it so that fourmat updates don't show up in the scheduled "non-major dependency updates".

fourmat minor version bumps should be treated as major bumps since they typically involve bumping up versions of black, flake8 etc and therefore require more than a quick PR merge.