### PR TITLE
chore: don't include fourmat dependencies in non-major update PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -28,7 +28,13 @@
         "found",
         "found-relay",
         "found-scroll",
-        "scroll-behavior"
+        "scroll-behavior",
+        "black",
+        "flake8",
+        "flake8-bugbear",
+        "isort",
+        "pycodestyle",
+        "pyflakes"
       ],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"


### PR DESCRIPTION
The formatting and linting libs brought in by fourmat often result in failing builds on renovate PRs. These should be updated manually when updating fourmat