### PR TITLE
chore: ignore fourmat deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -28,13 +28,7 @@
         "found",
         "found-relay",
         "found-scroll",
-        "scroll-behavior",
-        "black",
-        "flake8",
-        "flake8-bugbear",
-        "isort",
-        "pycodestyle",
-        "pyflakes"
+        "scroll-behavior"
       ],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
@@ -53,6 +47,14 @@
       "updateTypes": ["minor"],
       "versioning": "lockfile-major"
     }
+  ],
+  "ignoreDeps": [
+      "black",
+      "flake8",
+      "flake8-bugbear",
+      "isort",
+      "pycodestyle",
+      "pyflakes"
   ],
   "rangeStrategy": "bump",
   "postUpdateOptions": "yarnDedupeHighest",


### PR DESCRIPTION
#8 isn't enough; we also want to ignore major update PRs to these deps