### PR TITLE
chore: remove pip-compile handling

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,9 +11,6 @@
   "pip_requirements": {
     "fileMatch": ["(^|/)requirements(-dev)?\\.txt"]
   },
-  "pip-compile": {
-    "fileMatch": ["(^|/)requirements(-dev)?\\.in"]
-  },
   "pip_setup": {
     "enabled": false
   },


### PR DESCRIPTION
afaict from [the docs](https://docs.renovatebot.com/modules/manager/pip-compile/), renovate doesn't support configuring command-line arguments, so there isn't a way to pass `--no-annotate`
