### PR TITLE
chore: ignore postgres

### DIFF
--- a/default.json
+++ b/default.json
@@ -51,6 +51,7 @@
       "flake8-bugbear",
       "isort",
       "mccabe",
+      "postgres",
       "pycodestyle",
       "pyflakes"
   ],


### PR DESCRIPTION
postgres should be bumped manually in Dockerfile/docker-compose.yml to match RDS version